### PR TITLE
Update WandListener.java

### DIFF
--- a/src/main/java/com/nannerss/eternalore/listeners/WandListener.java
+++ b/src/main/java/com/nannerss/eternalore/listeners/WandListener.java
@@ -26,7 +26,7 @@ public class WandListener implements Listener {
         Player p = e.getPlayer();
         Action a = e.getAction();
         
-        if (!p.getItemInHand().hasItemMeta()) {
+        if (p.getInventory().getItemInHand() == null || !p.getItemInHand().hasItemMeta()) {
             return;
         }
         


### PR DESCRIPTION
Error before this change

28.12 06:38:00 [Server] ERROR Could not pass event PlayerInteractEvent to RespawningOres v1.0
28.12 06:38:00 [Server] INFO org.bukkit.event.EventException
28.12 06:38:00 [Server] INFO at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:310) ~[spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:62) ~[spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at org.bukkit.plugin.SimplePluginManager.fireEvent(SimplePluginManager.java:502) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:487) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at org.bukkit.craftbukkit.v1_8_R3.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:228) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at org.bukkit.craftbukkit.v1_8_R3.event.CraftEventFactory.callPlayerInteractEvent(CraftEventFactory.java:195) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at net.minecraft.server.v1_8_R3.PlayerInteractManager.a(PlayerInteractManager.java:107) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at net.minecraft.server.v1_8_R3.PlayerConnection.a(PlayerConnection.java:623) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at net.minecraft.server.v1_8_R3.PacketPlayInBlockDig.a(SourceFile:40) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at net.minecraft.server.v1_8_R3.PacketPlayInBlockDig.a(SourceFile:10) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at net.minecraft.server.v1_8_R3.PlayerConnectionUtils$1.run(SourceFile:13) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:1.8.0_191]
28.12 06:38:00 [Server] INFO at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:1.8.0_191]
28.12 06:38:00 [Server] INFO at net.minecraft.server.v1_8_R3.SystemUtils.a(SourceFile:44) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at net.minecraft.server.v1_8_R3.MinecraftServer.B(MinecraftServer.java:715) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at net.minecraft.server.v1_8_R3.DedicatedServer.B(DedicatedServer.java:374) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at net.minecraft.server.v1_8_R3.MinecraftServer.A(MinecraftServer.java:654) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at net.minecraft.server.v1_8_R3.MinecraftServer.run(MinecraftServer.java:557) [spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO at java.lang.Thread.run(Thread.java:748) [?:1.8.0_191]
28.12 06:38:00 [Server] INFO Caused by: java.lang.NoSuchMethodError: org.bukkit.inventory.PlayerInventory.getItemInMainHand()Lorg/bukkit/inventory/ItemStack;
28.12 06:38:00 [Server] INFO at io.github.bananapuncher714.RespawningOresMain.onPlayerInteractEvent(RespawningOresMain.java:93) ~[?:?]
28.12 06:38:00 [Server] INFO at sun.reflect.GeneratedMethodAccessor98.invoke(Unknown Source) ~[?:?]
28.12 06:38:00 [Server] INFO at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_191]
28.12 06:38:00 [Server] INFO at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_191]
28.12 06:38:00 [Server] INFO at org.bukkit.plugin.java.JavaPluginLoader$1.execute(JavaPluginLoader.java:306) ~[spigot-1.8.8.jar:git-Spigot-21fe707-e1ebe52]
28.12 06:38:00 [Server] INFO ... 18 more